### PR TITLE
fix: Ignore guest-mode replies to the bot's own messages

### DIFF
--- a/src/telegram/bot/download.ts
+++ b/src/telegram/bot/download.ts
@@ -18,6 +18,7 @@ import {
     OutputButton,
 } from "@/telegram/helpers/handler"
 import { deferredReply, replyText } from "@/telegram/helpers/sent"
+import { getBotId } from "@/telegram/helpers/self"
 import { getPeerSettings } from "@/telegram/helpers/settings"
 import { evaluatorsFor } from "@/telegram/helpers/text"
 
@@ -106,6 +107,10 @@ downloadDp.onBotGuestChatQuery(async (ctx) => {
     const msg = ctx.replyToMessage
     if (!msg)
         return
+
+    if (msg.sender.id === getBotId())
+        return
+
     const peer = ctx.message.sender
 
     const settings = await getPeerSettings(peer)

--- a/src/telegram/bot/index.ts
+++ b/src/telegram/bot/index.ts
@@ -10,6 +10,7 @@ import { settingsDp } from "@/telegram/bot/settings"
 import { startDp } from "@/telegram/bot/start"
 import { statsDp } from "@/telegram/bot/stats"
 import { env } from "@/telegram/helpers/env"
+import { setBotId } from "@/telegram/helpers/self"
 
 const bot = new TelegramClient({
     apiId: env.API_ID,
@@ -30,7 +31,8 @@ dp.extend(downloadDp)
 
 export async function startBot() {
     bot.start({ botToken: env.BOT_TOKEN })
-        .then(async () => {
+        .then(async (self) => {
+            setBotId(self.id)
             if (env.ERROR_CHAT_ID)
                 await bot.sendText(env.ERROR_CHAT_ID, "started bot :з")
         })

--- a/src/telegram/helpers/self.ts
+++ b/src/telegram/helpers/self.ts
@@ -1,0 +1,9 @@
+let botId: number | undefined
+
+export function setBotId(id: number) {
+    botId = id
+}
+
+export function getBotId(): number | undefined {
+    return botId
+}


### PR DESCRIPTION
Fixes a guest-mode loop: replying to one of the bot's own messages (whose caption contains the source URL when attribution is enabled) caused it to re-download that URL.